### PR TITLE
Fix bug in escapeUrlSegment

### DIFF
--- a/src/ExHack/Renderer/Types.hs
+++ b/src/ExHack/Renderer/Types.hs
@@ -75,7 +75,7 @@ newtype HighLightError = HighLightError String
 instance Exception HighLightError
 
 escapeUrlSegment :: Text -> Text
-escapeUrlSegment = pack . escapeURIString isReserved . unpack
+escapeUrlSegment = pack . escapeURIString (not . isReserved) . unpack
 
 -- | Render a 'Route' to a proper HTTP URL.
 renderRoute :: Render Route


### PR DESCRIPTION
[escapeURIString](https://hackage.haskell.org/package/network-uri-2.6.1.0/docs/Network-URI.html#v:escapeURIString) expects its first argument to return `False` for characters that should be escaped, therefore the first argument should be `not . isReserved`.

This should fix #10. 

Cool project, by the way!